### PR TITLE
Resolve cyclic dependency

### DIFF
--- a/celements-common-test/pom.xml
+++ b/celements-common-test/pom.xml
@@ -41,12 +41,6 @@
     <!-- Add here all your dependencies -->
     <dependency>
       <groupId>com.celements</groupId>
-      <artifactId>celements-component</artifactId>
-      <version>5.1-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.celements</groupId>
       <artifactId>celements-xwiki-core</artifactId>
       <version>5.2-SNAPSHOT</version>
       <scope>provided</scope>


### PR DESCRIPTION
```
One or more cycles were detected in the build path of project 'celements-common-test'. The paths towards the cycle and cycle are:
  ->{celements-common-test, celements-component}
```
Thus removed the dependency `celements-component` from `celements-common-test` since we don't need it **currently**.